### PR TITLE
Adds ackback and related consume settings

### DIFF
--- a/MBC_userImport.class.inc
+++ b/MBC_userImport.class.inc
@@ -97,28 +97,35 @@ class MBC_UserImport
     $deliveryTags = array();
     list($targetUsers, $deliveryTags) = $this->consumeUserImportQueue();
 
-    foreach ($targetUsers as $userCount => $user) {
+    if (count ($targetUsers) > 0) {
 
-      // Create Drupal user - https://github.com/DoSomething/dosomething/wiki/API#users
-      list($drupalUser, $user->password) = $this->createDrupalUser($user);
+      foreach ($targetUsers as $userCount => $user) {
 
-      if (isset($drupalUser->uid)) {
+        // Create Drupal user - https://github.com/DoSomething/dosomething/wiki/API#users
+        list($drupalUser, $user->password) = $this->createDrupalUser($user);
 
-        // With new user account details from Drupal site:
-        // Send transaction to transactionalExchange for distribution to
-        // transactionalQueue, userAPIRegistrationQueue and userRegistrationQueue
-        $status = $this->userImportProducer($user, $drupalUser);
+        if (isset($drupalUser->uid)) {
 
-        // Ack message
-        if ($status == TRUE) {
-          $this->channel->basic_ack($deliveryTags[$userCount]);
+          // With new user account details from Drupal site:
+          // Send transaction to transactionalExchange for distribution to
+          // transactionalQueue, userAPIRegistrationQueue and userRegistrationQueue
+          $status = $this->userImportProducer($user, $drupalUser);
+
+          // Ack message
+          if ($status == TRUE) {
+            $this->channel->basic_ack($deliveryTags[$userCount]);
+          }
+
+        }
+        else {
+          echo 'Failed to create Drupal user account.', "\n";
         }
 
       }
-      else {
-        echo 'Failed to create Drupal user account.', "\n";
-      }
 
+    }
+    else {
+      echo 'userImportQueue is empty.', "\n";
     }
 
     echo '------- mbc-user-import->produceUserImport() END: ' . date('D M j G:i:s T Y') . ' -------', "\n";

--- a/mbc-user-import.php
+++ b/mbc-user-import.php
@@ -49,6 +49,13 @@ $config = array(
       'bindingKey' => getenv("MB_USER_IMPORT_QUEUE_BINDING_KEY"),
     ),
   ),
+  'consume' => array(
+    'consumer_tag' => getenv("MB_USER_IMPORT_CONSUME_TAG"),
+    'no_local' => getenv("MB_USER_IMPORT_CONSUME_NO_LOCAL"),
+    'no_ack' => getenv("MB_USER_IMPORT_CONSUME_NO_ACK"),
+    'exclusive' => getenv("MB_USER_IMPORT_CONSUME_EXCLUSIVE"),
+    'nowait' => getenv("MB_USER_IMPORT_CONSUME_NOWAIT"),
+  ),
   'routingKey' => getenv("MB_USER_IMPORT_ROUTING_KEY"),
 );
 $settings = array(


### PR DESCRIPTION
Fixes #11 

Adds ack back call wen Drupal user is created. Only make additional entries in related queues when user is created.
