### PR TITLE
Adds StatHat logging

### DIFF
--- a/MBC_userImport.class.inc
+++ b/MBC_userImport.class.inc
@@ -240,7 +240,7 @@ class MBC_UserImport
     curl_close($ch);
 
     $this->statHat->clearAddedStatNames();
-    $this->statHat->addStatName('createDrupalUser');
+    $this->statHat->addStatName('Requested createDrupalUser');
     $this->statHat->reportCount(1);
 
     return array($result, $password);
@@ -448,6 +448,9 @@ class MBC_UserImport
       }
       else {
         echo($user->email . ' already a Drupal user.' . "\n");
+        $this->statHat->clearAddedStatNames();
+        $this->statHat->addStatName('Existing DrupalUser');
+        $this->statHat->reportCount(1);
       }
     }
     else {


### PR DESCRIPTION
Adds StatHat logging to:
- general consuming of the CSV import file: `consumeCSVImport`
- creation of new Drupal user: `createDrupalUser`
  - track existing Drupal user account: `Existing DrupalUser`
- log when the transaction is distributed to other queues / consumers: `Distribute user import - user.registration.transactional`
- log when new user is sent the temporary Drupal user password email: `Sent user_password-niche`
- log when an existing Mailchimp account is found for the email: `Mailchimp - existing account`
- log when an existing Mobile Commons account is found for the phone number: `Mobile Commons - existing account`
