### PR TITLE
Issue51 after school

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mbc-user-import",
   "type": "project",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A consummer app for the Message Broker system that creates entries in other user creation related queues. Each entry is an import of users from typically marketing partners that have expressed an interest in DoSomething.",
   "keywords": ["message broker"],
   "homepage": "https://github.com/DoSomething/mbc-user-import",

--- a/src/MBC_UserImport_BaseSource.php
+++ b/src/MBC_UserImport_BaseSource.php
@@ -123,7 +123,7 @@ abstract class MBC_UserImport_BaseSource
    * @param array $user
    *   Setting specific to the user being imported.
    *
-   * @return array &$payload
+   * @return array $payload
    *   Adjusted based on email and user settings.
    */
   abstract public function addWelcomeEmailSettings($user, &$payload);
@@ -134,7 +134,7 @@ abstract class MBC_UserImport_BaseSource
    * @param array $user
    *   Setting specific to the user being imported.
    *
-   * @return array &$payload
+   * @return array $payload
    *   Adjusted based on email and user settings.
    */
   abstract public function addEmailSubscriptionSettings($user, &$payload);
@@ -145,7 +145,7 @@ abstract class MBC_UserImport_BaseSource
    * @param array $user
    *   Setting specific to the user being imported.
    *
-   * @return array &$payload
+   * @return array $payload
    *   Adjusted based on email and user settings.
    */
   abstract public function addWelcomeSMSSettings($user, &$payload);

--- a/src/MBC_UserImport_BaseSource.php
+++ b/src/MBC_UserImport_BaseSource.php
@@ -118,17 +118,35 @@ abstract class MBC_UserImport_BaseSource
   abstract public function process();
 
   /**
+   * Settings specific to welcome email messages
    *
+   * @param array $user
+   *   Setting specific to the user being imported.
+   *
+   * @return array &$payload
+   *   Adjusted based on email and user settings.
    */
   abstract public function addWelcomeEmailSettings($user, &$payload);
 
   /**
+   * Settings specific to email subscriptions (MailChimp lists).
    *
+   * @param array $user
+   *   Setting specific to the user being imported.
+   *
+   * @return array &$payload
+   *   Adjusted based on email and user settings.
    */
   abstract public function addEmailSubscriptionSettings($user, &$payload);
 
   /**
+   * Settings specific to SMS welcome message.
    *
+   * @param array $user
+   *   Setting specific to the user being imported.
+   *
+   * @return array &$payload
+   *   Adjusted based on email and user settings.
    */
   abstract public function addWelcomeSMSSettings($user, &$payload);
 

--- a/src/MBC_UserImport_Consumer.php
+++ b/src/MBC_UserImport_Consumer.php
@@ -17,6 +17,11 @@ class MBC_UserImport_Consumer extends MB_Toolbox_BaseConsumer
 {
 
   /**
+   * The amount of time for the application to sleep / wait when an exception is encountered.
+   */
+  const SLEEP = 10;
+
+  /**
    * User settings to be used for general import message generation.
    *
    * @var array $user
@@ -63,13 +68,13 @@ class MBC_UserImport_Consumer extends MB_Toolbox_BaseConsumer
     catch(Exception $e) {
 
       if (strpos($e->getMessage(), 'Failed to generate password') !== false) {
-        echo '- Error message: ' . $e->getMessage() . ', retry in 10 seconds.', PHP_EOL;
-        sleep(10);
+        echo '- Error message: ' . $e->getMessage() . ', retry in ' . self::SLEEP . ' seconds.', PHP_EOL;
+        sleep(self::SLEEP);
         $this->messageBroker->sendNack($this->message['payload']);
       }
       elseif (strpos($e->getMessage(), 'Failed to create Drupal user') !== false) {
-        echo '- Error message: ' . $e->getMessage() . ', retry in 10 seconds.', PHP_EOL;
-        sleep(10);
+        echo '- Error message: ' . $e->getMessage() . ', retry in ' . self::SLEEP . ' seconds.', PHP_EOL;
+        sleep(self::SLEEP);
         $this->messageBroker->sendNack($this->message['payload']);
       }
       else {

--- a/src/MBC_UserImport_Source_AfterSchool.php
+++ b/src/MBC_UserImport_Source_AfterSchool.php
@@ -145,6 +145,30 @@ class MBC_UserImport_Source_AfterSchool extends MBC_UserImport_BaseSource
   }
 
   /**
+   * NOT USED
+   * Settings specific to welcome email messages
+   *
+   * @param array $user
+   *   Setting specific to the user being imported.
+   *
+   * @return array &$payload
+   *   Adjusted based on email and user settings.
+   */
+  public function addWelcomeEmailSettings($user, &$payload) {}
+
+  /**
+   * NOT USED
+   * Settings specific to email subscriptions (MailChimp lists).
+   *
+   * @param array $user
+   *   Setting specific to the user being imported.
+   *
+   * @return array &$payload
+   *   Adjusted based on email and user settings.
+   */
+  public function addEmailSubscriptionSettings($user, &$payload) {}
+
+  /**
    * addWelcomeSMSSettings(): Add settings to message payload that are specific to SMS.
    *
    * @param array $user

--- a/src/MBC_UserImport_Source_AfterSchool.php
+++ b/src/MBC_UserImport_Source_AfterSchool.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * MBC_UserImport_Source_AfterSchool; Settings and methods specific to user import
+ * date from After School.
+ */
+ 
+namespace DoSomething\MBC_UserImport;
+
+use DoSomething\MBC_UserImport\MBC_UserImport_BaseSource;
+use \Exception;
+
+class MBC_UserImport_Source_AfterSchool extends MBC_UserImport_BaseSource
+{
+
+  /**
+   * Constructor for MBC_UserImport_Source_AfterSchool - extension of the base source class
+   * that's specific to Niche.
+   */
+  public function __construct() {
+
+    parent::__construct();
+    $this->sourceName = 'AfterSchool';
+    $this->mbcUserImportToolbox = new MBC_UserImport_Toolbox();
+  }
+
+  /**
+   * canProcess(): Test if message can be processed by consumer. Niche user imports must have at
+   * least an email address.
+   *
+   * @param array
+   *   The message contents to test if it can be processed.
+   */
+  public function canProcess($message) {
+    
+   if (empty($message['mobile'])) {
+      echo '- canProcess(), mobile not set.', PHP_EOL;
+      parent::reportErrorPayload();
+      throw new Exception('canProcess(), mobile number not set.');
+    }
+
+    // Validate phone number based on the North American Numbering Plan
+    // https://en.wikipedia.org/wiki/North_American_Numbering_Plan
+    $regex = "/^(\d[\s-]?)?[\(\[\s-]{0,2}?\d{3}[\)\]\s-]{0,2}?\d{3}[\s-]?\d{4}$/i";
+    if (!(preg_match( $regex, $message['mobile']))) {
+      echo '** canProcess(): Invalid phone number based on North American Numbering Plan standard: ' .  $message['mobile'], PHP_EOL;
+      throw new Exception('canProcess(), Invalid phone number based on North American Numbering Plan standard.');
+    }
+
+    if (isset($message['mobile']) && empty($message['mobile_opt_in_path_id'])) {
+      echo 'mobile_opt_in_path_id not set when mobile is set.', PHP_EOL;
+      throw new Exception('canProcess(), mobile_opt_in_path_id not set when mobile is set.');
+    }
+
+    return true;
+  }
+
+  /**
+   * setter(): Assign values from message to class propertry for processing.
+   *
+   * @param array
+   *   The values from the message consumed from the queue.
+   */
+  public function setter($message) {
+    
+    if (isset($message['source'])) {
+      $this->importUser['user_registration_source'] = $message['source'];
+    }
+    else {
+      $this->importUser['user_registration_source'] = 'AfterSchool';
+    }
+    if (isset($message['source_file'])) {
+      $this->importUser['origin'] = $message['source_file'];
+    }
+    if (isset($message['activity_timestamp'])) {
+      $this->importUser['activity_timestamp'] = $message['activity_timestamp'];
+    }
+
+    if (isset($message['mobile'])) {
+      $this->importUser['mobile'] = $message['mobile'];
+    }
+    if (isset($message['mobile_opt_in_path_id'])) {
+      $this->importUser['mobile_opt_in_path_id'] = $message['mobile_opt_in_path_id'];
+    }
+
+    if (isset($message['first_name'])) {
+      $this->importUser['first_name'] = $message['first_name'];
+    }
+    if (isset($message['last_name'])) {
+      $this->importUser['last_name'] = $message['last_name'];
+    }
+
+    if (isset($message['hs_name'])) {
+      $this->importUser['hs_name'] = $message['hs_name'];
+    }
+    if (isset($message['hs_id'])) {
+      $this->importUser['hs_id'] = $message['hs_id'];
+    }
+  }
+
+  /**
+   * process(): Functional hum of class specific to the source. Defined steps specific
+   * to Niche user import.
+   */
+  public function process() {
+
+    $payload = $this->addCommonPayload($this->importUser);
+    $existing['log-type'] = 'user-import-afterschool';
+    $existing['source'] = $payload['source'];
+
+    // Check for existing user account in Mobile Commons
+    $this->mbcUserImportToolbox->checkExistingSMS($this->importUser, $existing);
+    
+    // Add SMS welcome details to payload
+    if (empty($existing['mobile-acquired'])) {
+      $this->addWelcomeSMSSettings($this->importUser, $payload);
+    }
+
+    // @todo: transition to using JSON formatted messages when all of the consumers are able to
+    // detect the message format and process either seralized or JSON.
+    $message = serialize($payload);
+    $this->messageBroker_transactionals->publish($message, 'user.registration.transactional');
+
+    // Log existing users
+    $this->mbcUserImportToolbox->logExisting($existing, $this->importUser);
+  }
+
+  /**
+   * addCommonPayload(): Add common setting to message payload based on
+   * After School user imports.
+   *
+   * @param array $user
+   *   Current user data values.
+   *
+   * @return array $payload
+   *   Update payload values formatted for distribution to consumers in
+   *   the Message Broker system.
+   */
+  public function addCommonPayload($user) {
+
+    $payload = $this->mbcUserImportToolbox->addCommonPayload($user);
+    $payload['activity'] = 'user_welcome-afterschool';
+    $payload['source'] = 'afterschool';
+
+    return $payload;
+  }
+
+  /**
+   * addWelcomeSMSSettings(): Add settings to message payload that are specific to SMS.
+   *
+   * @param array $user
+   *   Settings specific to the user data being imported.
+   *   
+   * @return array &$payload
+   *   Values formatted for submission to SMS API.
+   */
+  public function addWelcomeSMSSettings($user, &$payload) {
+
+    if (isset($user['mobile'])) {
+      $payload['mobile'] = $user['mobile'];
+      $payload['mobile_opt_in_path_id'] = $user['mobile_opt_in_path_id'];
+    }
+  }
+
+}

--- a/src/MBC_UserImport_Source_AfterSchool.php
+++ b/src/MBC_UserImport_Source_AfterSchool.php
@@ -107,13 +107,8 @@ class MBC_UserImport_Source_AfterSchool extends MBC_UserImport_BaseSource
     $existing['log-type'] = 'user-import-afterschool';
     $existing['source'] = $payload['source'];
 
-    // Check for existing user account in Mobile Commons
     $this->mbcUserImportToolbox->checkExistingSMS($this->importUser, $existing);
-    
-    // Add SMS welcome details to payload
-    if (empty($existing['mobile-acquired'])) {
-      $this->addWelcomeSMSSettings($this->importUser, $payload);
-    }
+    $this->addWelcomeSMSSettings($this->importUser, $payload);
 
     // @todo: transition to using JSON formatted messages when all of the consumers are able to
     // detect the message format and process either seralized or JSON.

--- a/src/MBC_UserImport_Source_AfterSchool.php
+++ b/src/MBC_UserImport_Source_AfterSchool.php
@@ -177,6 +177,11 @@ class MBC_UserImport_Source_AfterSchool extends MBC_UserImport_BaseSource
     if (isset($user['mobile'])) {
       $payload['mobile'] = $user['mobile'];
       $payload['mobile_opt_in_path_id'] = $user['mobile_opt_in_path_id'];
+
+      if (isset($user['hs_name'])) {
+        $payload['hs_name'] = $user['hs_name'];
+        $payload['hs_id'] = $user['hs_id'];
+      }
     }
   }
 

--- a/src/MBC_UserImport_Source_Niche.php
+++ b/src/MBC_UserImport_Source_Niche.php
@@ -40,7 +40,7 @@ class MBC_UserImport_Source_Niche extends MBC_UserImport_BaseSource
    if (filter_var($message['email'], FILTER_VALIDATE_EMAIL) === false) {
       echo '- canProcess(), failed FILTER_VALIDATE_EMAIL: ' . $message['email'], PHP_EOL;
       parent::reportErrorPayload();
-      return false;
+      throw new Exception('canProcess(), failed FILTER_VALIDATE_EMAIL: ' . $message['email']);
     }
     elseif (isset($message['email'])) {
       $this->message['email'] = filter_var($message['email'], FILTER_VALIDATE_EMAIL);


### PR DESCRIPTION
Fixes #51 

Add `AfterSchool` as a possible user import source.

Build message for distribution (`user.registration.transactional`) to consumers that result in:
- SMS message 
- User storage in `mb-user` database via `mb-user-api` -> `mbc-userAPI-registration`.

**To Test**:
- `mbp-user-import` will produce a message in `userImportQueue`:
```
{"subscribed":1,"activity_timestamp":1455041108,"application_id":100,"source":"AfterSchool","source_file":"2016-02-05-13-17-00.csv","mobile":"1234567890","last_name":"Blow","first_name":"Joe","hs_name":"DoSomething","hs_id":11500000000001,"user_country":"US","mobile_opt_in_path_id":200527,"requested":"2016-02-09T13:16:36-05:00","startTime":"2016-02-09T13:05:02-05:00"}
```
`mbc-user-import` will consume the message and generate messages in:
- `mobileCommonsQueue`
- `loggingGatewayQueue`
- `userAPIRegistrationQueue`

This has been tested and confirmed to be functional. A general code review would be very helpful.