### PR TITLE
Integrate Niche import with Gambit.

### DIFF
--- a/src/MBC_UserImport_Source_Niche.php
+++ b/src/MBC_UserImport_Source_Niche.php
@@ -326,12 +326,16 @@ class MBC_UserImport_Source_Niche extends MBC_UserImport_BaseSource
       'niche',
       false
     );
+
     if (!$campaignSignup) {
       // User was not signed up to campaign because they're already signed up.
       // #3, current_signedup, Existing/Existing
       $payload['email_template'] = self::WELCOME_EMAIL_EXISTING_EXISTING;
       $payload['tags'][0] = 'current-signedup-user-welcome-niche';
       $payload['tags'][1] = self::WELCOME_EMAIL_EXISTING_EXISTING;
+    } else {
+      $payload['event_id'] = $campaignNID;
+      $payload['signup_id'] = $campaignSignup;
     }
 
     // Check for existing user account in Mobile Commons
@@ -429,6 +433,8 @@ class MBC_UserImport_Source_Niche extends MBC_UserImport_BaseSource
     if (isset($user['mobile']) && self::MOBILE_COMMONS_SIGNUP !== false) {
       $payload['mobile'] = $user['mobile'];
       $payload['mobile_opt_in_path_id'] = self::MOBILE_COMMONS_SIGNUP;
+    } elseif (isset($user['mobile'])) {
+      $payload['mobile'] = $user['mobile'];
     }
   }
 

--- a/src/MBC_UserImport_Toolbox.php
+++ b/src/MBC_UserImport_Toolbox.php
@@ -364,7 +364,7 @@ class MBC_UserImport_Toolbox
    * @param string  $source         The name of the import source
    * @param bool    $transactionals Supress sending transaction messages.
    *
-   * @return bool Was the user signed up to the campaign.
+   * @return bool|int Was the user signed up to the campaign or signup id
    */
   public function campaignSignup(
     $campaignNID,
@@ -393,7 +393,7 @@ class MBC_UserImport_Toolbox
         'mbc-user-import: MBC_UserImport_Toolbox: campaignSignup',
         1
       );
-      return true;
+      return $signUp[0][0];
     } else {
       echo 'Drupal UID: ' . $drupalUID . ' may already be signed up for '
         . 'campaign ' . $campaignNID . ' or campaign is not accepting signups.'


### PR DESCRIPTION
#### What's this PR do?
- Always add mobile phone to the payload, even with MoCo turned off
- Save and pass campaign id and signup id to the payload on successful signup
- Return signup id instead of `true` from `MBC_UserImport_Toolbox::campaignSignup()`.

#### What are the relevant tickets?
Relevant changes to mbc-registration-mobile: DoSomething/mbc-registration-mobile#60.
