### PR TITLE
Niche: switch campaign to Take Back the Shelves.

### DIFF
--- a/src/MBC_UserImport_Source_Niche.php
+++ b/src/MBC_UserImport_Source_Niche.php
@@ -36,16 +36,16 @@ use \Exception;
 class MBC_UserImport_Source_Niche extends MBC_UserImport_BaseSource
 {
   // Mandrill email templates.
-  const WELCOME_EMAIL_NEW_NEW = 'mb-niche-welcome_new-new_v1-6-0';
-  const WELCOME_EMAIL_EXISTING_NEW = 'mb-niche-welcome_existing-new_v1-6-0';
-  const WELCOME_EMAIL_EXISTING_EXISTING = 'mb-niche-welcome_existing-existing_v1-6-0';
+  const WELCOME_EMAIL_NEW_NEW = 'mb-niche-welcome_new-new_v1-7-0';
+  const WELCOME_EMAIL_EXISTING_NEW = 'mb-niche-welcome_existing-new_v1-7-0';
+  const WELCOME_EMAIL_EXISTING_EXISTING = 'mb-niche-welcome_existing-existing_v1-7-0';
 
   // Off.
   const MOBILE_COMMONS_SIGNUP = false;
 
-  // Senior Story Swap
-  // https://www.dosomething.org/us/campaigns/senior-story-swap
-  const PHOENIX_SIGNUP = 4944;
+  // Take Back the Shelves
+  // https://www.dosomething.org/us/campaigns/take-back-shelves
+  const PHOENIX_SIGNUP = 7277;
 
   /**
    * Constructor for MBC_UserImport_Source_Nice - extension of the base source


### PR DESCRIPTION
#### What's this PR do?
- Changes Phoenix campaign nid to 7277
- Updates Mandrill templates to `v1-7-0`

cc @jamjensen 
