### PR TITLE
Fixes fatal error in AfterSchool imports.

### DIFF
--- a/src/MBC_UserImport_Source_AfterSchool.php
+++ b/src/MBC_UserImport_Source_AfterSchool.php
@@ -158,7 +158,7 @@ class MBC_UserImport_Source_AfterSchool extends MBC_UserImport_BaseSource
     $existing['log-type'] = 'user-import-afterschool';
     $existing['source'] = $payload['source'];
 
-    $this->mbcUserImportToolbox->checkExistingSMS($this->importUser, $existing);
+    $this->mbcUserImportToolbox->getMobileCommonsStatus($this->importUser, $existing);
     $this->addWelcomeSMSSettings($this->importUser, $payload);
 
     // Remove submitting source if account already exists in Mobile Commons to


### PR DESCRIPTION
Fixes:

```
PHP Fatal error:  Call to undefined method DoSomething\MBC_UserImport\MBC_UserImport_Toolbox::checkExistingSMS() in /opt/rabbit/mbc-user-import/src/MBC_UserImport_Source_AfterSchool.php on line 161
```