### PR TITLE
Catch up with Phoenix signup API endpoint update

### DIFF
--- a/src/MBC_UserImport_Source_Niche.php
+++ b/src/MBC_UserImport_Source_Niche.php
@@ -286,7 +286,7 @@ class MBC_UserImport_Source_Niche extends MBC_UserImport_BaseSource
     // If exiting user, check if already subscribed to promo campaign.
     if (!$userIsNew) {
       $campaignSignupId = $this->mbcUserImportToolbox->checkSignup(
-        $identity->id,
+        $identity->drupal_id,
         self::PHOENIX_SIGNUP
       );
     }


### PR DESCRIPTION
This PR is to implement create signup endpoint updates corresponding with a change to it introduced in https://github.com/DoSomething/phoenix/pull/7354.

Now script checks for an existing user signup before posting new signup. Prior to this change whether a user is subscribed to the campaign has been determined by creating signup response: it used to return FALSE when the signup already exists.

Closes #109.

