### PR TITLE
Fix birthdate field import

### DIFF
--- a/src/MBC_UserImport_Source_Niche.php
+++ b/src/MBC_UserImport_Source_Niche.php
@@ -156,7 +156,6 @@ class MBC_UserImport_Source_Niche extends MBC_UserImport_BaseSource
       }
       $this->user['birthdate'] = date('Y-m-d', $birthdateTimestamp);
     }
-    var_dump($this->user['birthdate']);
 
     // Country. Assume users are from the US.
     $this->user['country'] = !empty($message['country']) ? $message['country'] : 'US';

--- a/src/MBC_UserImport_Source_Niche.php
+++ b/src/MBC_UserImport_Source_Niche.php
@@ -148,13 +148,16 @@ class MBC_UserImport_Source_Niche extends MBC_UserImport_BaseSource
       }
     }
     // Birthday.
-    if (!empty($message['birthday'])) {
+    if (!empty($message['birthdate'])) {
       if (is_int($message['birthdate']) || ctype_digit($message['birthdate'])) {
-        $this->user['birthdate'] = (int) $message['birthdate'];
+        $birthdateTimestamp = (int) $message['birthdate'];
       } else {
-        $this->user['birthdate'] = strtotime($message['birthdate']);
+        $birthdateTimestamp = strtotime($message['birthdate']);
       }
+      $this->user['birthdate'] = date('Y-m-d', $birthdateTimestamp);
     }
+    var_dump($this->user['birthdate']);
+
     // Country. Assume users are from the US.
     $this->user['country'] = !empty($message['country']) ? $message['country'] : 'US';
     // Zip. Handle both `zip` and `postal_code` import field names.


### PR DESCRIPTION
Fixes birthdate field in Niche co-reg imports:

- Fixes a mistake with `$message['birthday']` instead if `$message['birthdate']`
- Fixes acceptable format for Northstar `POST v1/users`: convert from epoch time to ISO


Fixes #113